### PR TITLE
Bump support to iOS9+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "AgoraRtcKit",
     defaultLocalization: "en",
-    platforms: [.iOS(.v8)],
+    platforms: [.iOS(.v9)],
     products: [
         .library(
             name: "AgoraRtcKit",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install Agora Audio SDK easily with Swift Package Manager.
 
 ## Installation
 
-Add the URL of this repository to your Xcode 11+ Project.
+Add the URL of this repository to your Xcode 12+ Project.
 
 Go to _File > Swift Packages > Add Package Dependency_, and paste in the link to this repository:
 


### PR DESCRIPTION
on Xcode 12+ the minimum deployment target supported is iOS 9 so adding this package gets a warning. I wonder if bumping the package support to iOS9+ would cause anyone grief?